### PR TITLE
The default address/port of the web server can be configured in the '.env' file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,5 @@ MAILER_URL=smtp://localhost:2525?encryption=&auth_mode=
 SMTP_SERVER_USER=
 SMTP_SERVER_PASSWORD=
 SMTP_SERVER_PORT=2525
+WEB_SERVER_ADDRESSPORT=
 ###< jfoucher/mailocal ###

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Safely test sending your emails by using this local SMTP server and viewing the results on the web interface.
 
-By using this locally installed SMTP server you can be sure that your real customers will never see your test emails !
+By using this locally installed SMTP server you can be sure that your real customers will never see your test emails!
 
 However you can see all of them by simply opening the provided interface in any browser.
 
@@ -46,26 +46,26 @@ Alternatively you can:
 
 - Run `yarn run build` to build the frontend assets
 - `php bin/console email:server` to launch the SMTP server
-- `php bin/console server:start` to start Symfony's built-in webserver
+- `php bin/console server:start` to start Symfony's built-in web server
 
 ## Configuration
 
-- Configure your other apps to use this new local SMTP server : 
-  - host : `127.0.0.1`
+- Configure your other apps to use this new local SMTP server:
+  - host: `127.0.0.1`
   - port: `2525` (or the one you chose, see below)
-  - You can configure an SMTP username and password by setting the `SMTP_SERVER_USER` and `SMTP_SERVER_PASSWORD`
- fields in you `.env` file. Make sure you update your email client's credentials accordingly.
- - [Mailocal](/) uses an SQLite database by default (in `var/data.db`) but you can choose to use any other database by setting the correct URL in the `.env` file
- 
+  - You can configure a SMTP username and password by setting the `SMTP_SERVER_USER` and `SMTP_SERVER_PASSWORD` fields in your `.env` file. Make sure you update your email client's credentials accordingly.
+- [Mailocal](/) uses an SQLite database by default (in `var/data.db`) but you can choose to use any other database by setting the correct URL in the `.env` file.
+- By default, `bin/mailocal` will start a web server that listens on 127.0.0.1 (address) and the first free port starting from 8000.  This is where you can view any emails you receive.  You can force `bin/mailocal` to always listen on a specific address/port by setting the value of `WEB_SERVER_ADDRESSPORT` in your `.env` file.  The value can be address:port, address, or port.
+
 ## Done
-You can now view any emails you receive by opening http://localhost:8000 in your browser
+You can now view any emails you receive by opening http://127.0.0.1:8000 in your browser
 
 The SMTP runs on port 2525 by default. Pass the `--port` option to use another one, like this: `php bin/console email:server --port=587`
 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
-  
+
 ## Warning
 
 Never use this in production, only run it on your local machine.

--- a/bin/mailocal
+++ b/bin/mailocal
@@ -1,5 +1,9 @@
 #!/usr/bin/env php
 <?php
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Dotenv\Dotenv;
+
 if (is_file(__DIR__.'/../vendor/autoload.php')) {
     // Installed locally
     require __DIR__.'/../vendor/autoload.php';
@@ -10,9 +14,18 @@ if (is_file(__DIR__.'/../vendor/autoload.php')) {
     throw new \Exception('Could not find composer autoload file. Current directory is '.__DIR__);
 }
 
-use Symfony\Component\Process\Process;
+$dotEnvFilename = \dirname(__DIR__) . '/.env';
+$envVars = (new Dotenv())->parse(\file_get_contents($dotEnvFilename), $dotEnvFilename);
 
-$web = new Process(['php', __DIR__.'/console', 'server:run'], null, null, null, 0);
+$webServerAddressPort = $envVars['WEB_SERVER_ADDRESSPORT'] ?? null;
+
+$runWebServerCmdParts = ['php', __DIR__.'/console', 'server:run'];
+
+if (\strlen($webServerAddressPort)) {
+    $runWebServerCmdParts[] = $webServerAddressPort;
+}
+
+$web = new Process($runWebServerCmdParts, null, null, null, 0);
 $web->setTty(Process::isTtySupported());
 $web->start(function ($type, $buffer) {
     if (Process::ERR === $type) {

--- a/symfony.lock
+++ b/symfony.lock
@@ -311,6 +311,9 @@
             "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
         }
     },
+    "symfony/mime": {
+        "version": "v4.4.1"
+    },
     "symfony/monolog-bridge": {
         "version": "v4.2.3"
     },
@@ -343,6 +346,9 @@
     },
     "symfony/polyfill-intl-icu": {
         "version": "v1.10.0"
+    },
+    "symfony/polyfill-intl-idn": {
+        "version": "v1.13.1"
     },
     "symfony/polyfill-mbstring": {
         "version": "v1.10.0"


### PR DESCRIPTION
Mailocal is super, thanks.  Was looking for something to replace Mailcatcher; very pleased to find a PHP alternative.

Our team works on virtual machines running bridged network adapters.  I wanted to be able to use `bin/mailocal` but have the web server listen on a specific address/port because the default is no good for us.  This small alteration allows to configure the 'default' web server address/port in `.env`.  

Hopefully some good to you.

Thanks again